### PR TITLE
Update deadline for lunch

### DIFF
--- a/content/lunch.html
+++ b/content/lunch.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <body style="font-family: monospace; text-align: center; letter-spacing:0.01em;">
-    <h1>REMEMBER TO SIGN UP FOR LUNCH BEFORE EVERY WEDNESDAY 10:00!</h1>
+    <h1>REMEMBER TO SIGN UP FOR LUNCH BEFORE EVERY THURSDAY 09:00!</h1>
 
     <h2>Have requests or simply missing from the list when you shouldn't be?<br>Write to Sebastian from HPC at slp@di.ku.dk</h2>
   </body>


### PR DESCRIPTION
Given that we now use another provider, the deadline is more flexible, and thus was moved to Thursday instead of Wednesday.